### PR TITLE
Change key curve and algorithm for generated keys

### DIFF
--- a/src/commands/key-generate.ts
+++ b/src/commands/key-generate.ts
@@ -12,7 +12,7 @@ export default class GenerateIdentityKeyCommand extends Command {
    * @override
    */
   protected async action(): Promise<void> {
-    const key = await JWK.generate('EC', 'secp256k1')
+    const key = await JWK.generate('EC', 'P-256')
     const pem = key.toPEM(true)
     try {
       const filename = await writeFile('./identity-key.pem', pem)

--- a/src/commands/payid-sign.ts
+++ b/src/commands/payid-sign.ts
@@ -70,6 +70,12 @@ export default class SignPayIdCommand extends Command {
   }
 }
 
+/**
+ * Returns the default algorithm to use to sign with the given jwk.
+ *
+ * @param jwk - The key being used to sign.
+ * @returns The default algorithm.
+ */
 export function getDefaultAlgorithm(
   jwk: JWKRSAKey | JWKECKey | JWKOctKey | JWKOKPKey,
 ): string {

--- a/src/commands/payid-sign.ts
+++ b/src/commands/payid-sign.ts
@@ -1,10 +1,10 @@
 import {
   convertToVerifiedAddress,
   signWithKeys,
-  getDefaultAlgorithm,
   IdentityKeySigningParams,
   toKey,
 } from '@payid-org/utils'
+import { JWKECKey, JWKOctKey, JWKOKPKey, JWKRSAKey } from 'jose'
 
 import Command from './Command'
 
@@ -68,4 +68,19 @@ export default class SignPayIdCommand extends Command {
         new IdentityKeySigningParams(toKey(key), getDefaultAlgorithm(key)),
     )
   }
+}
+
+export function getDefaultAlgorithm(
+  jwk: JWKRSAKey | JWKECKey | JWKOctKey | JWKOKPKey,
+): string {
+  if (jwk.kty === 'EC') {
+    return 'ES256'
+  }
+  if (jwk.kty === 'oct') {
+    return 'HS512'
+  }
+  if (jwk.kty === 'OKP') {
+    return 'EdDSA'
+  }
+  return 'RS512'
 }

--- a/test/unit/getDefaultAlgorithm.test.ts
+++ b/test/unit/getDefaultAlgorithm.test.ts
@@ -1,0 +1,19 @@
+import 'mocha'
+import { assert } from 'chai'
+import { JWK } from 'jose'
+
+import { getDefaultAlgorithm } from '../../src/commands/payid-sign'
+
+describe('when getDefaultAlgorithm()', function (): void {
+  it('given an EC key then returns ES256', async function (): Promise<void> {
+    const key = await JWK.generate('EC')
+    const algorithm = getDefaultAlgorithm(key.toJWK())
+    assert.equal(algorithm, 'ES256')
+  })
+
+  it('given an RSA key then returns RS512', async function (): Promise<void> {
+    const key = await JWK.generate('RSA')
+    const algorithm = getDefaultAlgorithm(key.toJWK())
+    assert.equal(algorithm, 'RS512')
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

Change default curve and algorithm to P-256 / ES256 because secp256k1 / ES256k does not have wide support by JWS libraries.

### Context of Change

Per jwt.io, ES256k is not supported by the majority of JWT libraries, and none for .Net, Go, Rust, and browser-based JS libraries.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Before: generate  and sign commands would generate an sepc256k1 key and sign with ES256k.
After: generate  and sign commands generate an P-256 key and sign with ES256.
## Test Plan

Unit tests
Manually run the `keys generate` and `sign` commands and verify that the signed PayID has the expected curve and algorithm in the protected section.