### PR TITLE
change the `sign` command to clear unsigned addresses by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,12 @@ Before you sign an PayID, you must either load the PayID using the `load` comman
 
 Once a PayID has been initialized or loaded, you can sign it using an [identity key](#identity-keys). You must either generate a new key, or load an existing one. Once your PayID has been loaded or initialized, and your identity key has been generated or loaded,
 you can sign the PayID using `sign` command. The `sign` command signs each of your PayID address
-mappings using the loaded identity keys, and outputs the resulting PayID with a `verifiedAddress` field. Run the `save`
-command to save your PayID, with signed addresses, to file.
+mappings using the loaded identity keys, and outputs the resulting PayID with a `verifiedAddress` field.
+
+By default, the sign command clears the unsigned `addresses` from the results. If you wish to
+retain unsigned addresses after signing, use `sign --keep-addresses` or `sign -k` instead.
+
+Finally, run the `save` command to save your PayID, with signed addresses, to file.
 
 ### Inspect a Verified PayID
 

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -30,10 +30,15 @@ abstract class Command {
     this.vorpal = vorpal
   }
 
-  public setup(): void {
+  /**
+   * Sets up and registers the vorpal command.
+   *
+   * @returns The registered command.
+   */
+  public setup(): Vorpal.Command {
     // Register the concrete command to Vorpal.
     // Execute the concrete action inside a try/catch wrapper
-    this.vorpal.command(this.command(), this.description()).action(
+    return this.vorpal.command(this.command(), this.description()).action(
       async (args: Args): Promise<void> => {
         await this.action(args).catch((error) => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- error has any type

--- a/test/unit/signPayId.test.ts
+++ b/test/unit/signPayId.test.ts
@@ -1,0 +1,50 @@
+import 'mocha'
+import {
+  AddressDetailsType,
+  IdentityKeySigningParams,
+  PaymentInformation,
+} from '@payid-org/utils'
+import { assert } from 'chai'
+import { JWK } from 'jose'
+
+import { signPayId } from '../../src/commands/payid-sign'
+
+const info: PaymentInformation = {
+  payId: 'boaty$mcboatface.com',
+  addresses: [
+    {
+      paymentNetwork: 'boatcoin',
+      environment: 'seanet',
+      addressDetailsType: AddressDetailsType.CryptoAddress,
+      addressDetails: {
+        address: 'xyz12345',
+      },
+    },
+  ],
+  verifiedAddresses: [],
+}
+
+describe('when signPayId()', function (): void {
+  let signingKey: IdentityKeySigningParams
+
+  beforeEach('create key', async function (): Promise<void> {
+    const key = await JWK.generate('EC', 'P-256')
+    signingKey = new IdentityKeySigningParams(key, 'ES256')
+  })
+
+  it('called with keepAddresses=true, then addresses property is retained', async function (): Promise<
+    void
+  > {
+    const result = signPayId(info, [signingKey], true)
+    assert.equal(result.addresses, info.addresses)
+    assert.lengthOf(result.verifiedAddresses, 1)
+  })
+
+  it('called with keepAddresses=false, then addresses property is cleared', async function (): Promise<
+    void
+  > {
+    const result = signPayId(info, [signingKey], false)
+    assert.isEmpty(result.addresses)
+    assert.lengthOf(result.verifiedAddresses, 1)
+  })
+})


### PR DESCRIPTION
add an option `-k, --keep-addresses` to override default and retain unsigned addresses

Based on feedback that preferred behavior for V.PayID should be to force clients to use the verifiedAddresses and not provide unsigned addresses as a fallback method.